### PR TITLE
linux/drv.h: fix class_create depending on kernel version

### DIFF
--- a/linux/drv.h
+++ b/linux/drv.h
@@ -349,7 +349,11 @@ static int __init Init_Drv(void)
   DrvMinor = MINOR (devno);
 
   // Create device node
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(6,3,13)
   pDrvDevClass = class_create (THIS_MODULE, DEVICE_NAME);
+#else
+  pDrvDevClass = class_create (THIS_MODULE->name);
+#endif
   if (IS_ERR (pDrvDevClass))
     goto error;
 


### PR DESCRIPTION
As class_create macro has changed from 6.4 branch, there is a need to add #ifdef directive check for kernel version verification in order to use different implementation.